### PR TITLE
2.0.0

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run check
+      - run: npm run check:code
       - run: npm test
       - run: npm run build --if-present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ### Added
 
-- :warning: **[breaking-change]** Add an identifier for each function registration. When using a same identifier, **the new registered function(s) replace(s) the previous one(s)**.
+- :warning: **[breaking-change]** Add an identifier for each function registration. When using the same identifier, **the new registered function(s) replace(s) the previous one(s)**.
 
-- :warning: **[breaking-change]** Add an identifier for predicates functions to mimic to same behavior as functions registrations. Several predicate functions can now be passed in a single `if()` with a defined identifier. In the same way, if an another `if()` predicate is set with the same identifier, **it will override the previous one**.
+- :warning: **[breaking-change]** Add an identifier for predicates functions to mimic to the same behavior as functions registrations. Several predicate functions can now be passed in a single `if()` with a defined identifier. In the same way, if another `if()` predicate is set with the same identifier, **it will override the previous one**.
 
-- Add `deleteFunctionsWhenJobsStarted` option allowing to delete the registered functions when the jobs are started.
+- Add `deleteFunctionsWhenJobsStarted` option allowing the deletion of registered functions when the jobs are started.
 
-- Add `debug.logFunctionRegistrations` and `debug.logFunctionExecutions` options allowing functions registrations and executions logs. Don't forget to set `DEBUG=AsyncProcess:*` as an environment variable or in your browser's localstorage.
+- Add `debug.logFunctionRegistrations` and `debug.logFunctionExecutions` options allowing functions registrations and executions logs. Don't forget to set `DEBUG=AsyncProcess:*` as an environment variable or in your browser's local storage.
 
-- Keep errors thrown by jobs as it.
+- Keep errors thrown by jobs as is.
 
   Example: If the job is a fetch query and if the response is a 404, the `err` object will be a Response object.
 
-- AsyncProcess instances now accepts two more generics, a results (`R`) and an error (`E`), allowing to type results and error.
+- AsyncProcess instances now accept two more generics, results (`R`) and an error (`E`), allowing to enforce typings of jobs results and jobs exceptions.
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@
 
 - :warning: **[breaking-change]** Add an identifier for predicates functions to mimic to same behavior as functions registrations. Several predicate functions can now be passed in a single `if()` with a defined identifier. In the same way, if an another `if()` predicate is set with the same identifier, **it will override the previous one**.
 
-- Add an option `deleteFunctionsWhenJobsStarted` allowing to delete the registered functions when the jobs are started.
+- Add `deleteFunctionsWhenJobsStarted` option allowing to delete the registered functions when the jobs are started.
 
-- Add an option `debug.logFunctionRegistrations` and `debug.logFunctionExecutions` to debug functions registrations and executions. Don't forget to set `DEBUG=AsyncProcess:*` as an environment variable or in your browser's localstorage.
+- Add `debug.logFunctionRegistrations` and `debug.logFunctionExecutions` options allowing functions registrations and executions logs. Don't forget to set `DEBUG=AsyncProcess:*` as an environment variable or in your browser's localstorage.
+
+- Keep errors thrown by jobs as it.
+
+  Example: If the job is a fetch query and if the response is a 404, the `err` object will be a Response object.
+
+- AsyncProcess instances now accepts two more generics, a results (`R`) and an error (`E`), allowing to type results and error.
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.0.0
+
+### Added
+
+- :warning: **[breaking-change]** Add an identifier for each function registration. When using a same identifier, **the new registered function(s) replace(s) the previous one(s)**.
+
+- :warning: **[breaking-change]** Add an identifier for predicates functions to mimic to same behavior as functions registrations. Several predicate functions can now be passed in a single `if()` with a defined identifier. In the same way, if an another `if()` predicate is set with the same identifier, **it will override the previous one**.
+
+- Add an option `deleteFunctionsWhenJobsStarted` allowing to delete the registered functions when the jobs are started.
+
+- Add an option `debug.logFunctionRegistrations` and `debug.logFunctionExecutions` to debug functions registrations and executions. Don't forget to set `DEBUG=AsyncProcess:*` as an environment variable or in your browser's localstorage.
+
 ## v1.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ It's important to note that nothing is happening unless the `start` function is 
 
 In order to retrieve the same `AsyncProcess` declarations accross your application, `AsyncProcess` is an unique singleton that saves all instances.
 
-Each instance are referenced via an identifer and optional sub identifiers.
+Each instance are referenced via an identifer and optional sub identifiers. There is no inheritance between AsyncProcess instances meaning that an instance with a same identifier but different sub-identifiers are two different instances.
 
-The first identifier can be typed, typically by using an union of different string values, allowing to retrieve your instances in a safe way. Optional sub identifiers can be used for uuid or any arguments that identify your async process more precisely.
+The first identifier can be typed, typically by using an union of different string values, allowing to retrieve your instances in a safe way. Optional sub identifiers are generally used by [composite functions](#composition) (`with(...)`) for internal AsyncProcess instances.
 
 ### Typed identifiers
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ AsyncProcess.instance('initUsersPage', ['optionalIdentifier'])
   .onSuccess(hideSpinner)
   // call the `showError` function when the process is done and if it fails
   .onError(showError)
-  // start the async process
+  // start jobs
   .start()
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@productive-codebases/async-process",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@productive-codebases/async-process",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@productive-codebases/async-process",
-  "version": "1.2.0",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@productive-codebases/async-process",
-      "version": "1.2.0",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && mkdir dist && tsc --project tsconfig.build.json",
-    "check": "tsc --noEmit",
+    "check:code": "tsc --noEmit",
     "lint": "eslint .",
-    "prepublishOnly": "npm run check && npm run lint && npm t && npm run build",
+    "prepublishOnly": "npm run check:code && npm run lint && npm t && npm run build",
     "test": "jest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@productive-codebases/async-process",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Declare, configure and start asynchronous processes with ease.",
   "author": "Alexis MINEAUD",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check:code": "tsc --noEmit",
     "lint": "eslint .",
     "prepublishOnly": "npm run check:code && npm run lint && npm t && npm run build",
-    "test": "jest"
+    "test": "DEBUG_COLORS=0 DEBUG_HIDE_DATE=true jest"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@productive-codebases/async-process",
-  "version": "1.2.0",
+  "version": "2.0.0-beta.0",
   "description": "Declare, configure and start asynchronous processes with ease.",
   "author": "Alexis MINEAUD",
   "license": "MIT",

--- a/src/AsyncProcess/composers/__tests__/withLogs.test.ts
+++ b/src/AsyncProcess/composers/__tests__/withLogs.test.ts
@@ -28,7 +28,7 @@ describe('Composers', () => {
       const logger = jest.fn()
 
       await getAsyncProcessTestInstance('loadFoo')
-        .do(() => doSomething())
+        .do(doSomething)
         .compose(withLogs(logger))
         .start()
 
@@ -65,7 +65,7 @@ describe('Composers', () => {
       const logger3 = jest.fn()
 
       await getAsyncProcessTestInstance('loadFoo')
-        .do(() => doSomething())
+        .do(doSomething)
         .compose(withLogs(logger1))
         .compose(withLogs(logger2, 'secondLogger'))
         .compose(withLogs(logger3, 'thirdLogger'))

--- a/src/AsyncProcess/composers/withLogs.ts
+++ b/src/AsyncProcess/composers/withLogs.ts
@@ -36,12 +36,12 @@ export function withLogs<TIdentifier extends string>(
     ])
       .onStart(() => {
         logger('Start %s', asyncProcess.identifier)
-      })
+      }, identifier)
       .onSuccess(() => {
         logger('Success %s', asyncProcess.identifier)
-      })
+      }, identifier)
       .onError(err => {
         logger('Error %s: %o', asyncProcess.identifier, err)
-      })
+      }, identifier)
   }
 }

--- a/src/AsyncProcess/index.ts
+++ b/src/AsyncProcess/index.ts
@@ -34,7 +34,7 @@ export class AsyncProcess<TIdentifier extends string> {
     }
   }
 
-  private _error: Maybe<Error> = null
+  private _error: Maybe<unknown> = null
 
   private _fns: IAsyncProcessFns = {
     jobs: new Map(),
@@ -203,8 +203,8 @@ export class AsyncProcess<TIdentifier extends string> {
         await this._execJobs(this._fns.onSuccessFns)
       }
     } catch (err) {
-      this._error = err instanceof Error ? err : new Error('Unknown error')
-      this._execAsyncErrorFns(this._error, this._fns.onErrorFns)
+      this._error = err
+      this._execAsyncErrorFns(err, this._fns.onErrorFns)
     } finally {
       this.shouldDeleteFunctions()
     }
@@ -262,7 +262,7 @@ export class AsyncProcess<TIdentifier extends string> {
     return this._fns
   }
 
-  get error(): Maybe<Error> {
+  get error(): Maybe<unknown> {
     return this._error
   }
 
@@ -291,7 +291,7 @@ export class AsyncProcess<TIdentifier extends string> {
    * Execute sequentially async error functions.
    */
   private async _execAsyncErrorFns(
-    err: Error,
+    err: unknown,
     asyncErrorFns: Map<string, Set<AsyncErrorFn>>
   ): Promise<this> {
     for (const [identifier, fns] of asyncErrorFns.entries()) {

--- a/src/AsyncProcess/index.ts
+++ b/src/AsyncProcess/index.ts
@@ -197,20 +197,16 @@ export class AsyncProcess<TIdentifier extends string> {
     try {
       if (this._fns.predicateFns.size && !(await this.shouldStart())) {
         await this._execJobs(this._fns.onSuccessFns)
-
-        this.shouldDeleteFunctions()
-
-        return this
+      } else {
+        await this._execJobs(this._fns.onStartFns)
+        await this._execJobs(this._fns.jobs)
+        await this._execJobs(this._fns.onSuccessFns)
       }
-
-      await this._execJobs(this._fns.onStartFns)
-      await this._execJobs(this._fns.jobs)
-      await this._execJobs(this._fns.onSuccessFns)
-
-      this.shouldDeleteFunctions()
     } catch (err) {
       this._error = err instanceof Error ? err : new Error('Unknown error')
       this._execAsyncErrorFns(this._error, this._fns.onErrorFns)
+    } finally {
+      this.shouldDeleteFunctions()
     }
 
     return this

--- a/src/AsyncProcess/index.ts
+++ b/src/AsyncProcess/index.ts
@@ -25,7 +25,7 @@ export class AsyncProcess<TIdentifier extends string> {
      * When set to true, registered functions are deleted after AsyncProcess has been started.
      * Useful when reusing a same instance of AsyncProcess to not have functions registered several times.
      */
-    deleteFunctionsWhenStarted: false
+    deleteFunctionsWhenJobsStarted: false
   }
 
   private _error: Maybe<Error> = null
@@ -201,7 +201,7 @@ export class AsyncProcess<TIdentifier extends string> {
    * Reset functions.
    */
   shouldResetFunctions(): this {
-    if (!this._options.deleteFunctionsWhenStarted) {
+    if (!this._options.deleteFunctionsWhenJobsStarted) {
       return this
     }
 

--- a/src/AsyncProcess/index.ts
+++ b/src/AsyncProcess/index.ts
@@ -32,11 +32,7 @@ export class AsyncProcess<TIdentifier extends string, R = any, E = any> {
      * When set to true, registered functions are deleted after AsyncProcess has been started.
      * Useful when reusing a same instance of AsyncProcess to not have functions registered several times.
      */
-    deleteFunctionsWhenJobsStarted: false,
-    debug: {
-      logFunctionRegistrations: false,
-      logFunctionExecutions: false
-    }
+    deleteFunctionsWhenJobsStarted: false
   }
 
   private _error: Maybe<E> = null

--- a/src/AsyncProcess/predicates/olderThan.ts
+++ b/src/AsyncProcess/predicates/olderThan.ts
@@ -55,8 +55,7 @@ export function olderThan<TIdentifier extends string>(
       metadata.set({
         olderThan: {
           lastDate: newLastDate,
-          // when calling expireProcess(), delete lastData to set a new lastDate the next time
-          cancelDelay: () => metadata.delete('olderThan'),
+          cancelDelay: () => metadata.clear(),
           dependencies
         }
       })

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -21,12 +21,6 @@ describe('AsyncProcess', () => {
       }
     }
   ])('With options: %o', options => {
-    let data: Maybe<IData> = null
-
-    const setData = (data_: any) => {
-      data = data_
-    }
-
     function getAsyncProcessTestInstance(
       identifier: AsyncProcessTestIdentifier,
       subIdentifiers?: string[]
@@ -37,21 +31,14 @@ describe('AsyncProcess', () => {
     }
 
     beforeEach(() => {
-      data = null
       AsyncProcess.clearInstances()
     })
 
     describe('On success', () => {
       it('should call the onStart / onSuccess fn(s)', async () => {
-        const fetchData = (): Promise<null> => {
-          return new Promise(resolve => {
-            setTimeout(() => {
-              setData({ id: 1, name: 'Bob' })
-              resolve(null)
-            }, 50)
-          })
-        }
-
+        const fetchData = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve({ id: 1, name: 'Bob' }))
         const onStartFns = [jest.fn(), jest.fn()]
         const onSuccessFns = [jest.fn()]
         const onErrorFn = jest.fn()
@@ -73,21 +60,10 @@ describe('AsyncProcess', () => {
         })
 
         expect(onErrorFn).not.toHaveBeenCalled()
-
-        expect(data).toEqual({
-          id: 1,
-          name: 'Bob'
-        })
       })
 
       it('should call the functions sequentially', async () => {
-        const fetchData = (): Promise<null> => {
-          return new Promise(resolve => {
-            setTimeout(() => {
-              resolve(null)
-            }, 50)
-          })
-        }
+        const fetchData = jest.fn().mockImplementation(() => Promise.resolve())
 
         const successValues: number[] = []
 
@@ -111,13 +87,7 @@ describe('AsyncProcess', () => {
       })
 
       it('should return a success promise', async () => {
-        const fetchData = (): Promise<null> => {
-          return new Promise(resolve => {
-            setTimeout(() => {
-              resolve(null)
-            }, 50)
-          })
-        }
+        const fetchData = jest.fn().mockImplementation(() => Promise.resolve())
 
         const asyncProcess =
           getAsyncProcessTestInstance('loadFoo').do(fetchData)
@@ -164,14 +134,11 @@ describe('AsyncProcess', () => {
 
     describe('On error', () => {
       it('should call the onStart / onError fn(s)', async () => {
-        const fetchData = (): Promise<any> => {
-          return new Promise((_, reject) => {
-            setTimeout(() => {
-              reject(new Error('Something bad happened'))
-            }, 50)
-          })
-        }
-
+        const fetchData = jest
+          .fn()
+          .mockImplementation(() =>
+            Promise.reject(new Error('Something bad happened'))
+          )
         const onStartFns = [jest.fn(), jest.fn()]
         const onSuccessFns = [jest.fn()]
         const onErrorFn = jest.fn()
@@ -192,7 +159,7 @@ describe('AsyncProcess', () => {
           expect(onSuccessFn).not.toHaveBeenCalled()
         })
 
-        expect(data).toEqual(null)
+        expect(asyncProcess.result).toEqual(null)
       })
 
       it('should pass the Error to error functions', async () => {
@@ -200,14 +167,11 @@ describe('AsyncProcess', () => {
           constructor(readonly error: string) {}
         }
 
-        const fetchData = (): Promise<any> => {
-          return new Promise((_, reject) => {
-            setTimeout(() => {
-              reject(new CustomError('Something bad happened'))
-            }, 50)
-          })
-        }
-
+        const fetchData = jest
+          .fn()
+          .mockImplementation(() =>
+            Promise.reject(new CustomError('Something bad happened'))
+          )
         const onErrorFn = jest.fn()
 
         const asyncProcess = getAsyncProcessTestInstance('loadFoo')
@@ -226,20 +190,16 @@ describe('AsyncProcess', () => {
           constructor(readonly error: string) {}
         }
 
-        const fetchData = (): Promise<any> => {
-          return new Promise((_, reject) => {
-            setTimeout(() => {
-              reject(new CustomError('Something bad happened'))
-            }, 50)
-          })
-        }
-
+        const fetchData = jest
+          .fn()
+          .mockImplementation(() =>
+            Promise.reject(new CustomError('Something bad happened'))
+          )
         const asyncProcess =
           getAsyncProcessTestInstance('loadFoo').do(fetchData)
 
         await asyncProcess.start()
 
-        expect(data).toEqual(null)
         expect(asyncProcess.error).toBeInstanceOf(CustomError)
         expect(asyncProcess.error).toEqual(
           new CustomError('Something bad happened')
@@ -247,13 +207,7 @@ describe('AsyncProcess', () => {
       })
 
       it('should return a success promise even if an error occurred', async () => {
-        const fetchData = (): Promise<null> => {
-          return new Promise((_, reject) => {
-            setTimeout(() => {
-              reject()
-            }, 50)
-          })
-        }
+        const fetchData = jest.fn().mockImplementation(() => Promise.reject())
 
         let errorMessage: Maybe<string> = null
 
@@ -444,14 +398,9 @@ describe('AsyncProcess', () => {
 
     describe('AsyncProcess composition', () => {
       it('should compose AsyncProcess instances', async () => {
-        const fetchData = (): Promise<null> => {
-          return new Promise(resolve => {
-            setTimeout(() => {
-              setData({ id: 1, name: 'Bob' })
-              resolve(null)
-            }, 50)
-          })
-        }
+        const fetchData = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve({ id: 1, name: 'Bob' }))
 
         const onStartFn0 = jest.fn()
         const onStartFn1 = jest.fn()
@@ -506,7 +455,7 @@ describe('AsyncProcess', () => {
           options.deleteFunctionsWhenJobsStarted ? 0 : 4
         )
 
-        expect(data).toEqual({
+        expect(asyncProcess.result).toEqual({
           id: 1,
           name: 'Bob'
         })

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -1,5 +1,6 @@
 import { Maybe } from '@productive-codebases/toolbox'
 import { AsyncProcess } from '../AsyncProcess'
+import { IAsyncProcessOptions } from '../types'
 
 interface IData {
   id: number
@@ -8,486 +9,522 @@ interface IData {
 
 type AsyncProcessTestIdentifier = 'loadFoo' | 'loadBar'
 
-function getAsyncProcessTestInstance(
-  identifier: AsyncProcessTestIdentifier,
-  subIdentifiers?: string[]
-): AsyncProcess<AsyncProcessTestIdentifier> {
-  return AsyncProcess.instance(identifier, subIdentifiers)
-}
-
 describe('AsyncProcess', () => {
-  let data: Maybe<IData> = null
+  describe.each<IAsyncProcessOptions>([
+    { deleteFunctionsWhenStarted: false },
+    { deleteFunctionsWhenStarted: true }
+  ])('According to options: %o', ({ deleteFunctionsWhenStarted }) => {
+    let data: Maybe<IData> = null
 
-  const setData = (data_: any) => {
-    data = data_
-  }
+    const setData = (data_: any) => {
+      data = data_
+    }
 
-  beforeEach(() => {
-    data = null
-    AsyncProcess.clearInstances()
-  })
+    function getAsyncProcessTestInstance(
+      identifier: AsyncProcessTestIdentifier,
+      subIdentifiers?: string[]
+    ): AsyncProcess<AsyncProcessTestIdentifier> {
+      return AsyncProcess.instance(identifier, subIdentifiers).setOptions({
+        deleteFunctionsWhenStarted
+      })
+    }
 
-  describe('On success', () => {
-    it('should call the onStart / onSuccess fn(s)', async () => {
-      const fetchData = (): Promise<null> => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            setData({ id: 1, name: 'Bob' })
-            resolve(null)
-          }, 50)
+    beforeEach(() => {
+      data = null
+      AsyncProcess.clearInstances()
+    })
+
+    describe('On success', () => {
+      it('should call the onStart / onSuccess fn(s)', async () => {
+        const fetchData = (): Promise<null> => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              setData({ id: 1, name: 'Bob' })
+              resolve(null)
+            }, 50)
+          })
+        }
+
+        const onStartFns = [jest.fn(), jest.fn()]
+        const onSuccessFns = [jest.fn()]
+        const onErrorFn = jest.fn()
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .onStart(onStartFns)
+          .onSuccess(onSuccessFns)
+          .onError(onErrorFn)
+
+        await asyncProcess.start()
+
+        onStartFns.forEach(onStartFn => {
+          expect(onStartFn).toHaveBeenCalled()
         })
-      }
 
-      const onStartFns = [jest.fn(), jest.fn()]
-      const onSuccessFns = [jest.fn()]
-      const onErrorFn = jest.fn()
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .onStart(onStartFns)
-        .onSuccess(onSuccessFns)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      onStartFns.forEach(onStartFn => {
-        expect(onStartFn).toHaveBeenCalled()
-      })
-
-      onSuccessFns.forEach(onSuccessFn => {
-        expect(onSuccessFn).toHaveBeenCalled()
-      })
-
-      expect(onErrorFn).not.toHaveBeenCalled()
-
-      expect(data).toEqual({
-        id: 1,
-        name: 'Bob'
-      })
-    })
-
-    it('should call the functions sequentially', async () => {
-      const fetchData = (): Promise<null> => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve(null)
-          }, 50)
+        onSuccessFns.forEach(onSuccessFn => {
+          expect(onSuccessFn).toHaveBeenCalled()
         })
-      }
 
-      const successValues: number[] = []
+        expect(onErrorFn).not.toHaveBeenCalled()
 
-      const setSuccess = (value: number) => () => {
-        successValues.push(value)
-      }
-
-      const onStartFns = [jest.fn(), jest.fn()]
-      const onSuccessFns = [setSuccess(2), setSuccess(1)]
-      const onErrorFn = jest.fn()
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .onStart(onStartFns)
-        .onSuccess(onSuccessFns)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      expect(successValues).toEqual([2, 1])
-    })
-
-    it('should return a success promise', async () => {
-      const fetchData = (): Promise<null> => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve(null)
-          }, 50)
+        expect(data).toEqual({
+          id: 1,
+          name: 'Bob'
         })
-      }
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo').do(fetchData)
-
-      const doSomethingAfterAsyncProcess = jest.fn()
-
-      await asyncProcess.start().then(() => doSomethingAfterAsyncProcess())
-
-      expect(doSomethingAfterAsyncProcess).toHaveBeenCalled()
-    })
-  })
-
-  describe('On error', () => {
-    it('should call the onStart / onError fn(s)', async () => {
-      const fetchData = (): Promise<any> => {
-        return new Promise((_, reject) => {
-          setTimeout(() => {
-            reject(new Error('Something bad happened'))
-          }, 50)
-        })
-      }
-
-      const onStartFns = [jest.fn(), jest.fn()]
-      const onSuccessFns = [jest.fn()]
-      const onErrorFn = jest.fn()
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .onStart(onStartFns)
-        .onSuccess(onSuccessFns)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      onStartFns.forEach(onStartFn => {
-        expect(onStartFn).toHaveBeenCalled()
       })
 
-      onSuccessFns.forEach(onSuccessFn => {
-        expect(onSuccessFn).not.toHaveBeenCalled()
+      it('should call the functions sequentially', async () => {
+        const fetchData = (): Promise<null> => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(null)
+            }, 50)
+          })
+        }
+
+        const successValues: number[] = []
+
+        const setSuccess = (value: number) => () => {
+          successValues.push(value)
+        }
+
+        const onStartFns = [jest.fn(), jest.fn()]
+        const onSuccessFns = [setSuccess(2), setSuccess(1)]
+        const onErrorFn = jest.fn()
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .onStart(onStartFns)
+          .onSuccess(onSuccessFns)
+          .onError(onErrorFn)
+
+        await asyncProcess.start()
+
+        expect(successValues).toEqual([2, 1])
       })
 
-      expect(data).toEqual(null)
-    })
+      it('should return a success promise', async () => {
+        const fetchData = (): Promise<null> => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(null)
+            }, 50)
+          })
+        }
 
-    it('should pass the Error to error functions', async () => {
-      const error = new Error('Something bad happened')
+        const asyncProcess =
+          getAsyncProcessTestInstance('loadFoo').do(fetchData)
 
-      const fetchData = (): Promise<any> => {
-        return new Promise((_, reject) => {
-          setTimeout(() => {
-            reject(error)
-          }, 50)
-        })
-      }
+        const doSomethingAfterAsyncProcess = jest.fn()
 
-      const onErrorFn = jest.fn()
+        await asyncProcess.start().then(() => doSomethingAfterAsyncProcess())
 
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      expect(onErrorFn).toHaveBeenCalledWith(error)
-    })
-
-    it('should expose the Error', async () => {
-      const fetchData = (): Promise<any> => {
-        return new Promise((_, reject) => {
-          setTimeout(() => {
-            reject(new Error('Something bad happened'))
-          }, 50)
-        })
-      }
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo').do(fetchData)
-
-      await asyncProcess.start()
-
-      expect(data).toEqual(null)
-      expect(asyncProcess.error).toBeInstanceOf(Error)
-      expect(asyncProcess.error?.message).toEqual('Something bad happened')
-    })
-
-    it('should return a success promise even if an error occurred', async () => {
-      const fetchData = (): Promise<null> => {
-        return new Promise((_, reject) => {
-          setTimeout(() => {
-            reject()
-          }, 50)
-        })
-      }
-
-      let errorMessage: Maybe<string> = null
-
-      const setErrorMessage = (message: string) => () => {
-        errorMessage = message
-      }
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .onError(setErrorMessage('Something bad happened'))
-
-      const doSomethingAfterAsyncProcess = jest.fn()
-
-      await asyncProcess.start().then(() => doSomethingAfterAsyncProcess())
-
-      expect(doSomethingAfterAsyncProcess).toHaveBeenCalled()
-      expect(errorMessage).toEqual('Something bad happened')
-    })
-  })
-
-  describe('Identifiers', () => {
-    describe('onStart', () => {
-      it('should use a default identifier so that fns are replaced by default', () => {
-        const startSpy1 = jest.fn()
-        const startSpy2 = jest.fn()
-
-        const foo1 = getAsyncProcessTestInstance('loadFoo')
-        foo1.onStart(startSpy1)
-
-        const foo2 = getAsyncProcessTestInstance('loadFoo')
-        foo2.onStart(startSpy1)
-        foo2.onStart(startSpy2)
-
-        // register only `startSpy2` because added last
-        expect(foo1.fns.onStartFns.size).toBe(1)
+        expect(doSomethingAfterAsyncProcess).toHaveBeenCalled()
       })
     })
 
-    describe('onSuccess', () => {
-      it('should use a default identifier so that fns are replaced by default', () => {
-        const successSpy1 = jest.fn()
-        const successSpy2 = jest.fn()
+    describe('On error', () => {
+      it('should call the onStart / onError fn(s)', async () => {
+        const fetchData = (): Promise<any> => {
+          return new Promise((_, reject) => {
+            setTimeout(() => {
+              reject(new Error('Something bad happened'))
+            }, 50)
+          })
+        }
 
-        const foo1 = getAsyncProcessTestInstance('loadFoo')
-        foo1.onSuccess(successSpy1)
+        const onStartFns = [jest.fn(), jest.fn()]
+        const onSuccessFns = [jest.fn()]
+        const onErrorFn = jest.fn()
 
-        const foo2 = getAsyncProcessTestInstance('loadFoo')
-        foo2.onSuccess(successSpy1)
-        foo2.onSuccess(successSpy2)
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .onStart(onStartFns)
+          .onSuccess(onSuccessFns)
+          .onError(onErrorFn)
 
-        // register only `successSpy2` because added last
-        expect(foo1.fns.onSuccessFns.size).toBe(1)
-      })
+        await asyncProcess.start()
 
-      it('should allow using an identifier to add several fns', async () => {
-        const successSpy1 = jest.fn()
-        const successSpy2 = jest.fn()
-        const successSpy3 = jest.fn()
-        const successSpy4 = jest.fn()
-
-        const foo1 = getAsyncProcessTestInstance('loadFoo')
-        foo1.onSuccess([successSpy1, successSpy2], 'success1')
-
-        const foo2 = getAsyncProcessTestInstance('loadFoo')
-        foo2.onSuccess([successSpy3, successSpy4], 'success2')
-
-        // register `[successSpy1, successSpy2]` and `[successSpy3, successSpy4]`, so 2 entries
-        expect(foo1.fns.onSuccessFns.size).toBe(2)
-
-        await foo1.start()
-
-        // check that the 4 fns have been called
-        expect(successSpy1).toHaveBeenCalled()
-        expect(successSpy2).toHaveBeenCalled()
-        expect(successSpy3).toHaveBeenCalled()
-        expect(successSpy4).toHaveBeenCalled()
-      })
-    })
-
-    describe('onError', () => {
-      it('should use a default identifier so that fns are replaced by default', () => {
-        const errorSpy1 = jest.fn()
-        const errorSpy2 = jest.fn()
-
-        const foo1 = getAsyncProcessTestInstance('loadFoo')
-        foo1.onError(errorSpy1)
-
-        const foo2 = getAsyncProcessTestInstance('loadFoo')
-        foo2.onError(errorSpy1)
-        foo2.onError(errorSpy2)
-
-        // register only `errorSpy2` because added last
-        expect(foo1.fns.onErrorFns.size).toBe(1)
-      })
-    })
-  })
-
-  describe('Predicates', () => {
-    it('should execute the async process if the predicate function is true', async () => {
-      const fetchData = jest.fn()
-      const predicateFn1 = jest.fn().mockImplementation(() => true)
-      const predicateFn2 = jest.fn().mockImplementation(() => true)
-      const onStartFn = jest.fn()
-      const onSuccessFn = jest.fn()
-      const onErrorFn = jest.fn()
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .if(predicateFn1)
-        .if(predicateFn2)
-        .onStart(onStartFn)
-        .onSuccess(onSuccessFn)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      expect(predicateFn1).toHaveBeenCalled()
-      expect(predicateFn2).toHaveBeenCalled()
-      expect(fetchData).toHaveBeenCalled()
-      expect(onStartFn).toHaveBeenCalled()
-      expect(onSuccessFn).toHaveBeenCalled()
-      expect(onErrorFn).not.toHaveBeenCalled()
-    })
-
-    it('should not execute the async process if the predicate function is false', async () => {
-      const fetchData = jest.fn()
-      const predicateFn1 = jest.fn().mockImplementation(() => false)
-      const onStartFn = jest.fn()
-      const onSuccessFn = jest.fn()
-      const onErrorFn = jest.fn()
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .if(predicateFn1)
-        .onStart(onStartFn)
-        .onSuccess(onSuccessFn)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      expect(predicateFn1).toHaveBeenCalled()
-      expect(fetchData).not.toHaveBeenCalled()
-      expect(onStartFn).not.toHaveBeenCalled()
-      expect(onSuccessFn).toHaveBeenCalled()
-      expect(onErrorFn).not.toHaveBeenCalled()
-    })
-
-    it('should not execute the async process if one of the predicate functions is false', async () => {
-      const fetchData = jest.fn()
-      const predicateFn1 = jest.fn().mockImplementation(() => true)
-      const predicateFn2 = jest.fn().mockImplementation(() => true)
-      const predicateFn3 = jest.fn().mockImplementation(() => false)
-      const onStartFn = jest.fn()
-      const onSuccessFn = jest.fn()
-      const onErrorFn = jest.fn()
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .if(predicateFn1)
-        .if(predicateFn2)
-        .if(predicateFn3)
-        .onStart(onStartFn)
-        .onSuccess(onSuccessFn)
-        .onError(onErrorFn)
-
-      await asyncProcess.start()
-
-      expect(predicateFn1).toHaveBeenCalled()
-      expect(predicateFn2).toHaveBeenCalled()
-      expect(predicateFn3).toHaveBeenCalled()
-      expect(fetchData).not.toHaveBeenCalled()
-      expect(onStartFn).not.toHaveBeenCalled()
-      expect(onSuccessFn).toHaveBeenCalled()
-      expect(onErrorFn).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('AsyncProcess composition', () => {
-    it('should compose AsyncProcess instances', async () => {
-      const fetchData = (): Promise<null> => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            setData({ id: 1, name: 'Bob' })
-            resolve(null)
-          }, 50)
+        onStartFns.forEach(onStartFn => {
+          expect(onStartFn).toHaveBeenCalled()
         })
-      }
 
-      const onStartFn0 = jest.fn()
-      const onStartFn1 = jest.fn()
-      const onStartFn2 = jest.fn()
-      const onStartFn3 = jest.fn()
-      const onStartFn4 = jest.fn()
+        onSuccessFns.forEach(onSuccessFn => {
+          expect(onSuccessFn).not.toHaveBeenCalled()
+        })
 
-      const onSuccessFn = jest.fn()
+        expect(data).toEqual(null)
+      })
 
-      const onErrorFn = jest.fn()
+      it('should pass the Error to error functions', async () => {
+        const error = new Error('Something bad happened')
 
-      let asyncProcessBaseIdentifiers
+        const fetchData = (): Promise<any> => {
+          return new Promise((_, reject) => {
+            setTimeout(() => {
+              reject(error)
+            }, 50)
+          })
+        }
 
-      const asyncProcessExtended = (
-        asyncProcess: AsyncProcess<AsyncProcessTestIdentifier>
-      ) => {
-        const baseAsyncProcess = getAsyncProcessTestInstance(
-          asyncProcess.identifier,
-          ['id1', 'id2']
-        )
-          // define custom identifiers for each fns addition
-          .onStart(onStartFn1, 'onStartFn1')
-          .onStart(onStartFn2, 'onStartFn2')
-          .onStart([onStartFn3, onStartFn4], 'onStartFn3+onStartFn4')
+        const onErrorFn = jest.fn()
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .onError(onErrorFn)
+
+        await asyncProcess.start()
+
+        expect(onErrorFn).toHaveBeenCalledWith(error)
+      })
+
+      it('should expose the Error', async () => {
+        const fetchData = (): Promise<any> => {
+          return new Promise((_, reject) => {
+            setTimeout(() => {
+              reject(new Error('Something bad happened'))
+            }, 50)
+          })
+        }
+
+        const asyncProcess =
+          getAsyncProcessTestInstance('loadFoo').do(fetchData)
+
+        await asyncProcess.start()
+
+        expect(data).toEqual(null)
+        expect(asyncProcess.error).toBeInstanceOf(Error)
+        expect(asyncProcess.error?.message).toEqual('Something bad happened')
+      })
+
+      it('should return a success promise even if an error occurred', async () => {
+        const fetchData = (): Promise<null> => {
+          return new Promise((_, reject) => {
+            setTimeout(() => {
+              reject()
+            }, 50)
+          })
+        }
+
+        let errorMessage: Maybe<string> = null
+
+        const setErrorMessage = (message: string) => () => {
+          errorMessage = message
+        }
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .onError(setErrorMessage('Something bad happened'))
+
+        const doSomethingAfterAsyncProcess = jest.fn()
+
+        await asyncProcess.start().then(() => doSomethingAfterAsyncProcess())
+
+        expect(doSomethingAfterAsyncProcess).toHaveBeenCalled()
+        expect(errorMessage).toEqual('Something bad happened')
+      })
+    })
+
+    describe('Identifiers', () => {
+      describe('onStart', () => {
+        it('should use a default identifier so that fns are replaced by default', () => {
+          const startSpy1 = jest.fn()
+          const startSpy2 = jest.fn()
+
+          const foo1 = getAsyncProcessTestInstance('loadFoo')
+          foo1.onStart(startSpy1)
+
+          const foo2 = getAsyncProcessTestInstance('loadFoo')
+          foo2.onStart(startSpy1)
+          foo2.onStart(startSpy2)
+
+          // register only `startSpy2` because added last
+          expect(foo1.fns.onStartFns.size).toBe(1)
+        })
+      })
+
+      describe('onSuccess', () => {
+        it('should use a default identifier so that fns are replaced by default', () => {
+          const successSpy1 = jest.fn()
+          const successSpy2 = jest.fn()
+
+          const foo1 = getAsyncProcessTestInstance('loadFoo')
+          foo1.onSuccess(successSpy1)
+
+          const foo2 = getAsyncProcessTestInstance('loadFoo')
+          foo2.onSuccess(successSpy1)
+          foo2.onSuccess(successSpy2)
+
+          // register only `successSpy2` because added last
+          expect(foo1.fns.onSuccessFns.size).toBe(1)
+        })
+
+        it('should allow using an identifier to add several fns', async () => {
+          const successSpy1 = jest.fn()
+          const successSpy2 = jest.fn()
+          const successSpy3 = jest.fn()
+          const successSpy4 = jest.fn()
+
+          const foo1 = getAsyncProcessTestInstance('loadFoo')
+          foo1.onSuccess([successSpy1, successSpy2], 'success1')
+
+          const foo2 = getAsyncProcessTestInstance('loadFoo')
+          foo2.onSuccess([successSpy3, successSpy4], 'success2')
+
+          // register `[successSpy1, successSpy2]` and `[successSpy3, successSpy4]`, so 2 entries
+          expect(foo1.fns.onSuccessFns.size).toBe(2)
+
+          await foo1.start()
+
+          // check that the 4 fns have been called
+          expect(successSpy1).toHaveBeenCalled()
+          expect(successSpy2).toHaveBeenCalled()
+          expect(successSpy3).toHaveBeenCalled()
+          expect(successSpy4).toHaveBeenCalled()
+        })
+      })
+
+      describe('onError', () => {
+        it('should use a default identifier so that fns are replaced by default', () => {
+          const errorSpy1 = jest.fn()
+          const errorSpy2 = jest.fn()
+
+          const foo1 = getAsyncProcessTestInstance('loadFoo')
+          foo1.onError(errorSpy1)
+
+          const foo2 = getAsyncProcessTestInstance('loadFoo')
+          foo2.onError(errorSpy1)
+          foo2.onError(errorSpy2)
+
+          // register only `errorSpy2` because added last
+          expect(foo1.fns.onErrorFns.size).toBe(1)
+        })
+      })
+    })
+
+    describe('Predicates', () => {
+      it('should execute the async process if the predicate function is true', async () => {
+        const fetchData = jest.fn()
+        const predicateFn1 = jest.fn().mockImplementation(() => true)
+        const predicateFn2 = jest.fn().mockImplementation(() => true)
+        const onStartFn = jest.fn()
+        const onSuccessFn = jest.fn()
+        const onErrorFn = jest.fn()
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .if(predicateFn1)
+          .if(predicateFn2)
+          .onStart(onStartFn)
           .onSuccess(onSuccessFn)
           .onError(onErrorFn)
 
-        asyncProcessBaseIdentifiers = baseAsyncProcess.identitiers
+        await asyncProcess.start()
 
-        return baseAsyncProcess
-      }
-
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(fetchData)
-        .onStart(onStartFn0, 'onStartFn0')
-        .compose(asyncProcessExtended)
-
-      await asyncProcess.start()
-
-      expect(onStartFn0).toHaveBeenCalled()
-      expect(onStartFn1).toHaveBeenCalled()
-      expect(onStartFn2).toHaveBeenCalled()
-      expect(onStartFn3).toHaveBeenCalled()
-      expect(onStartFn4).toHaveBeenCalled()
-
-      expect(onSuccessFn).toHaveBeenCalled()
-
-      expect(onErrorFn).not.toHaveBeenCalled()
-
-      // Count the number of additions (by uniq identifiers) of onStartFns entries
-      expect(asyncProcess.fns.onStartFns.size).toEqual(4)
-
-      expect(data).toEqual({
-        id: 1,
-        name: 'Bob'
+        expect(predicateFn1).toHaveBeenCalled()
+        expect(predicateFn2).toHaveBeenCalled()
+        expect(fetchData).toHaveBeenCalled()
+        expect(onStartFn).toHaveBeenCalled()
+        expect(onSuccessFn).toHaveBeenCalled()
+        expect(onErrorFn).not.toHaveBeenCalled()
       })
 
-      expect(asyncProcessBaseIdentifiers).toEqual(['loadFoo', 'id1/id2'])
+      it('should not execute the async process if the predicate function is false', async () => {
+        const fetchData = jest.fn()
+        const predicateFn1 = jest.fn().mockImplementation(() => false)
+        const onStartFn = jest.fn()
+        const onSuccessFn = jest.fn()
+        const onErrorFn = jest.fn()
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .if(predicateFn1)
+          .onStart(onStartFn)
+          .onSuccess(onSuccessFn)
+          .onError(onErrorFn)
+
+        await asyncProcess.start()
+
+        expect(predicateFn1).toHaveBeenCalled()
+        expect(fetchData).not.toHaveBeenCalled()
+        expect(onStartFn).not.toHaveBeenCalled()
+        expect(onSuccessFn).toHaveBeenCalled()
+        expect(onErrorFn).not.toHaveBeenCalled()
+      })
+
+      it('should not execute the async process if one of the predicate functions is false', async () => {
+        const fetchData = jest.fn()
+        const predicateFn1 = jest.fn().mockImplementation(() => true)
+        const predicateFn2 = jest.fn().mockImplementation(() => true)
+        const predicateFn3 = jest.fn().mockImplementation(() => false)
+        const onStartFn = jest.fn()
+        const onSuccessFn = jest.fn()
+        const onErrorFn = jest.fn()
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .if(predicateFn1)
+          .if(predicateFn2)
+          .if(predicateFn3)
+          .onStart(onStartFn)
+          .onSuccess(onSuccessFn)
+          .onError(onErrorFn)
+
+        await asyncProcess.start()
+
+        expect(predicateFn1).toHaveBeenCalled()
+        expect(predicateFn2).toHaveBeenCalled()
+        expect(predicateFn3).toHaveBeenCalled()
+        expect(fetchData).not.toHaveBeenCalled()
+        expect(onStartFn).not.toHaveBeenCalled()
+        expect(onSuccessFn).toHaveBeenCalled()
+        expect(onErrorFn).not.toHaveBeenCalled()
+      })
     })
-  })
 
-  describe('Singleton', () => {
-    it('should return an unique instance for a same identifier', () => {
-      const successSpy = jest.fn()
+    describe('AsyncProcess composition', () => {
+      it('should compose AsyncProcess instances', async () => {
+        const fetchData = (): Promise<null> => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              setData({ id: 1, name: 'Bob' })
+              resolve(null)
+            }, 50)
+          })
+        }
 
-      const foo1 = getAsyncProcessTestInstance('loadFoo')
-      foo1.onSuccess(successSpy)
-      const foo2 = getAsyncProcessTestInstance('loadFoo')
+        const onStartFn0 = jest.fn()
+        const onStartFn1 = jest.fn()
+        const onStartFn2 = jest.fn()
+        const onStartFn3 = jest.fn()
+        const onStartFn4 = jest.fn()
 
-      const bar1 = getAsyncProcessTestInstance('loadBar')
-      const bar2 = getAsyncProcessTestInstance('loadBar')
+        const onSuccessFn = jest.fn()
 
-      expect(foo1).toBe(foo2)
-      expect(bar1).toBe(bar2)
+        const onErrorFn = jest.fn()
 
-      expect(foo1).not.toBe(bar1)
-      expect(foo2).not.toBe(bar2)
+        let asyncProcessBaseIdentifiers
 
-      expect(foo1.fns.onSuccessFns.size).toBe(1)
-      expect(foo2.fns.onSuccessFns.size).toBe(1)
+        const asyncProcessExtended = (
+          asyncProcess: AsyncProcess<AsyncProcessTestIdentifier>
+        ) => {
+          const baseAsyncProcess = getAsyncProcessTestInstance(
+            asyncProcess.identifier,
+            ['id1', 'id2']
+          )
+            // define custom identifiers for each fns addition
+            .onStart(onStartFn1, 'onStartFn1')
+            .onStart(onStartFn2, 'onStartFn2')
+            .onStart([onStartFn3, onStartFn4], 'onStartFn3+onStartFn4')
+            .onSuccess(onSuccessFn)
+            .onError(onErrorFn)
+
+          asyncProcessBaseIdentifiers = baseAsyncProcess.identitiers
+
+          return baseAsyncProcess
+        }
+
+        const asyncProcess = getAsyncProcessTestInstance('loadFoo')
+          .do(fetchData)
+          .onStart(onStartFn0, 'onStartFn0')
+          .compose(asyncProcessExtended)
+
+        await asyncProcess.start()
+
+        expect(onStartFn0).toHaveBeenCalled()
+        expect(onStartFn1).toHaveBeenCalled()
+        expect(onStartFn2).toHaveBeenCalled()
+        expect(onStartFn3).toHaveBeenCalled()
+        expect(onStartFn4).toHaveBeenCalled()
+
+        expect(onSuccessFn).toHaveBeenCalled()
+
+        expect(onErrorFn).not.toHaveBeenCalled()
+
+        // Count the number of additions (by uniq identifiers) of onStartFns entries
+        expect(asyncProcess.fns.onStartFns.size).toEqual(
+          deleteFunctionsWhenStarted ? 0 : 4
+        )
+
+        expect(data).toEqual({
+          id: 1,
+          name: 'Bob'
+        })
+
+        expect(asyncProcessBaseIdentifiers).toEqual(['loadFoo', 'id1/id2'])
+      })
     })
 
-    it('should return an unique instance for same identifiers', () => {
-      const successSpy = jest.fn()
+    describe('Singleton', () => {
+      it('should return an unique instance for a same identifier', () => {
+        const successSpy = jest.fn()
 
-      const foo1 = getAsyncProcessTestInstance('loadFoo')
-      foo1.onSuccess(successSpy)
+        const foo1 = getAsyncProcessTestInstance('loadFoo')
+        foo1.onSuccess(successSpy)
+        const foo2 = getAsyncProcessTestInstance('loadFoo')
 
-      const foo1Dep1 = getAsyncProcessTestInstance('loadFoo', ['dep1'])
-      const foo2Dep1 = getAsyncProcessTestInstance('loadFoo', ['dep1'])
+        const bar1 = getAsyncProcessTestInstance('loadBar')
+        const bar2 = getAsyncProcessTestInstance('loadBar')
 
-      const foo1Dep2 = getAsyncProcessTestInstance('loadFoo', ['dep2'])
-      const foo2Dep2 = getAsyncProcessTestInstance('loadFoo', ['dep2'])
+        expect(foo1).toBe(foo2)
+        expect(bar1).toBe(bar2)
 
-      expect(foo1Dep1).toBe(foo2Dep1)
-      expect(foo1Dep2).toBe(foo2Dep2)
+        expect(foo1).not.toBe(bar1)
+        expect(foo2).not.toBe(bar2)
 
-      expect(foo1).not.toBe(foo1Dep1)
-      expect(foo1Dep1).not.toBe(foo1Dep2)
+        expect(foo1.fns.onSuccessFns.size).toBe(1)
+        expect(foo2.fns.onSuccessFns.size).toBe(1)
+      })
 
-      expect(foo1Dep1.identifier).toBe('loadFoo')
-      expect(foo1Dep1.identitiers).toEqual(['loadFoo', 'dep1'])
+      it('should return an unique instance for same identifiers', () => {
+        const successSpy = jest.fn()
 
-      expect(foo1.fns.onSuccessFns.size).toBe(1)
-      expect(foo1Dep1.fns.onSuccessFns.size).toBe(0)
+        const foo1 = getAsyncProcessTestInstance('loadFoo')
+        foo1.onSuccess(successSpy)
+
+        const foo1Dep1 = getAsyncProcessTestInstance('loadFoo', ['dep1'])
+        const foo2Dep1 = getAsyncProcessTestInstance('loadFoo', ['dep1'])
+
+        const foo1Dep2 = getAsyncProcessTestInstance('loadFoo', ['dep2'])
+        const foo2Dep2 = getAsyncProcessTestInstance('loadFoo', ['dep2'])
+
+        expect(foo1Dep1).toBe(foo2Dep1)
+        expect(foo1Dep2).toBe(foo2Dep2)
+
+        expect(foo1).not.toBe(foo1Dep1)
+        expect(foo1Dep1).not.toBe(foo1Dep2)
+
+        expect(foo1Dep1.identifier).toBe('loadFoo')
+        expect(foo1Dep1.identitiers).toEqual(['loadFoo', 'dep1'])
+
+        expect(foo1.fns.onSuccessFns.size).toBe(1)
+        expect(foo1Dep1.fns.onSuccessFns.size).toBe(0)
+      })
+    })
+
+    describe('Options', () => {
+      describe('deleteFunctionsWhenStarted', () => {
+        it('should reset functions when async process is started', async () => {
+          const successSpy1 = jest.fn()
+          const successSpy2 = jest.fn()
+          const successSpy3 = jest.fn()
+
+          const foo1 = getAsyncProcessTestInstance('loadFoo')
+
+          foo1.onSuccess(successSpy1, 'success1')
+          foo1.onSuccess(successSpy2, 'success2')
+
+          expect(foo1.fns.onSuccessFns.size).toBe(2)
+
+          await foo1.start()
+
+          foo1.onSuccess(successSpy3, 'success3')
+
+          expect(foo1.fns.onSuccessFns.size).toBe(
+            deleteFunctionsWhenStarted ? 1 : 3
+          )
+        })
+      })
     })
   })
 })

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -43,7 +43,7 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
+        .do(fetchData)
         .onStart(onStartFns)
         .onSuccess(onSuccessFns)
         .onError(onErrorFn)
@@ -86,7 +86,7 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
+        .do(fetchData)
         .onStart(onStartFns)
         .onSuccess(onSuccessFns)
         .onError(onErrorFn)
@@ -105,9 +105,7 @@ describe('AsyncProcess', () => {
         })
       }
 
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo').do(() =>
-        fetchData()
-      )
+      const asyncProcess = getAsyncProcessTestInstance('loadFoo').do(fetchData)
 
       const doSomethingAfterAsyncProcess = jest.fn()
 
@@ -132,7 +130,7 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
+        .do(fetchData)
         .onStart(onStartFns)
         .onSuccess(onSuccessFns)
         .onError(onErrorFn)
@@ -164,7 +162,7 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
+        .do(fetchData)
         .onError(onErrorFn)
 
       await asyncProcess.start()
@@ -181,9 +179,7 @@ describe('AsyncProcess', () => {
         })
       }
 
-      const asyncProcess = getAsyncProcessTestInstance('loadFoo').do(() =>
-        fetchData()
-      )
+      const asyncProcess = getAsyncProcessTestInstance('loadFoo').do(fetchData)
 
       await asyncProcess.start()
 
@@ -208,7 +204,7 @@ describe('AsyncProcess', () => {
       }
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
+        .do(fetchData)
         .onError(setErrorMessage('Something bad happened'))
 
       const doSomethingAfterAsyncProcess = jest.fn()
@@ -217,6 +213,83 @@ describe('AsyncProcess', () => {
 
       expect(doSomethingAfterAsyncProcess).toHaveBeenCalled()
       expect(errorMessage).toEqual('Something bad happened')
+    })
+  })
+
+  describe('Identifiers', () => {
+    describe('onStart', () => {
+      it('should use a default identifier so that fns are replaced by default', () => {
+        const startSpy1 = jest.fn()
+        const startSpy2 = jest.fn()
+
+        const foo1 = getAsyncProcessTestInstance('loadFoo')
+        foo1.onStart(startSpy1)
+
+        const foo2 = getAsyncProcessTestInstance('loadFoo')
+        foo2.onStart(startSpy1)
+        foo2.onStart(startSpy2)
+
+        // register only `startSpy2` because added last
+        expect(foo1.fns.onStartFns.size).toBe(1)
+      })
+    })
+
+    describe('onSuccess', () => {
+      it('should use a default identifier so that fns are replaced by default', () => {
+        const successSpy1 = jest.fn()
+        const successSpy2 = jest.fn()
+
+        const foo1 = getAsyncProcessTestInstance('loadFoo')
+        foo1.onSuccess(successSpy1)
+
+        const foo2 = getAsyncProcessTestInstance('loadFoo')
+        foo2.onSuccess(successSpy1)
+        foo2.onSuccess(successSpy2)
+
+        // register only `successSpy2` because added last
+        expect(foo1.fns.onSuccessFns.size).toBe(1)
+      })
+
+      it('should allow using an identifier to add several fns', async () => {
+        const successSpy1 = jest.fn()
+        const successSpy2 = jest.fn()
+        const successSpy3 = jest.fn()
+        const successSpy4 = jest.fn()
+
+        const foo1 = getAsyncProcessTestInstance('loadFoo')
+        foo1.onSuccess([successSpy1, successSpy2], 'success1')
+
+        const foo2 = getAsyncProcessTestInstance('loadFoo')
+        foo2.onSuccess([successSpy3, successSpy4], 'success2')
+
+        // register `[successSpy1, successSpy2]` and `[successSpy3, successSpy4]`, so 2 entries
+        expect(foo1.fns.onSuccessFns.size).toBe(2)
+
+        await foo1.start()
+
+        // check that the 4 fns have been called
+        expect(successSpy1).toHaveBeenCalled()
+        expect(successSpy2).toHaveBeenCalled()
+        expect(successSpy3).toHaveBeenCalled()
+        expect(successSpy4).toHaveBeenCalled()
+      })
+    })
+
+    describe('onError', () => {
+      it('should use a default identifier so that fns are replaced by default', () => {
+        const errorSpy1 = jest.fn()
+        const errorSpy2 = jest.fn()
+
+        const foo1 = getAsyncProcessTestInstance('loadFoo')
+        foo1.onError(errorSpy1)
+
+        const foo2 = getAsyncProcessTestInstance('loadFoo')
+        foo2.onError(errorSpy1)
+        foo2.onError(errorSpy2)
+
+        // register only `errorSpy2` because added last
+        expect(foo1.fns.onErrorFns.size).toBe(1)
+      })
     })
   })
 
@@ -230,9 +303,9 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
-        .if(() => predicateFn1())
-        .if(() => predicateFn2())
+        .do(fetchData)
+        .if(predicateFn1)
+        .if(predicateFn2)
         .onStart(onStartFn)
         .onSuccess(onSuccessFn)
         .onError(onErrorFn)
@@ -255,8 +328,8 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
-        .if(() => predicateFn1())
+        .do(fetchData)
+        .if(predicateFn1)
         .onStart(onStartFn)
         .onSuccess(onSuccessFn)
         .onError(onErrorFn)
@@ -280,10 +353,10 @@ describe('AsyncProcess', () => {
       const onErrorFn = jest.fn()
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
-        .if(() => predicateFn1())
-        .if(() => predicateFn2())
-        .if(() => predicateFn3())
+        .do(fetchData)
+        .if(predicateFn1)
+        .if(predicateFn2)
+        .if(predicateFn3)
         .onStart(onStartFn)
         .onSuccess(onSuccessFn)
         .onError(onErrorFn)
@@ -311,12 +384,14 @@ describe('AsyncProcess', () => {
         })
       }
 
-      const onStartgFn1 = jest.fn()
-      const onStartgFn2 = jest.fn()
+      const onStartFn0 = jest.fn()
+      const onStartFn1 = jest.fn()
+      const onStartFn2 = jest.fn()
+      const onStartFn3 = jest.fn()
+      const onStartFn4 = jest.fn()
 
-      // Add two same functions, should be unique at the end
-      const onStartFns = [onStartgFn1, onStartgFn1, onStartgFn2]
-      const onSuccessFns = [jest.fn()]
+      const onSuccessFn = jest.fn()
+
       const onErrorFn = jest.fn()
 
       let asyncProcessBaseIdentifiers
@@ -326,10 +401,13 @@ describe('AsyncProcess', () => {
       ) => {
         const baseAsyncProcess = getAsyncProcessTestInstance(
           asyncProcess.identifier,
-          ['dep1', 'dep2']
+          ['id1', 'id2']
         )
-          .onStart(onStartFns)
-          .onSuccess(onSuccessFns)
+          // define custom identifiers for each fns addition
+          .onStart(onStartFn1, 'onStartFn1')
+          .onStart(onStartFn2, 'onStartFn2')
+          .onStart([onStartFn3, onStartFn4], 'onStartFn3+onStartFn4')
+          .onSuccess(onSuccessFn)
           .onError(onErrorFn)
 
         asyncProcessBaseIdentifiers = baseAsyncProcess.identitiers
@@ -338,30 +416,31 @@ describe('AsyncProcess', () => {
       }
 
       const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-        .do(() => fetchData())
+        .do(fetchData)
+        .onStart(onStartFn0, 'onStartFn0')
         .compose(asyncProcessExtended)
 
       await asyncProcess.start()
 
-      onStartFns.forEach(onStartFn => {
-        expect(onStartFn).toHaveBeenCalled()
-      })
+      expect(onStartFn0).toHaveBeenCalled()
+      expect(onStartFn1).toHaveBeenCalled()
+      expect(onStartFn2).toHaveBeenCalled()
+      expect(onStartFn3).toHaveBeenCalled()
+      expect(onStartFn4).toHaveBeenCalled()
 
-      onSuccessFns.forEach(onSuccessFn => {
-        expect(onSuccessFn).toHaveBeenCalled()
-      })
+      expect(onSuccessFn).toHaveBeenCalled()
 
       expect(onErrorFn).not.toHaveBeenCalled()
 
-      // Dedup same functions
-      expect(asyncProcess.fns.onStartFns.size).toEqual(2)
+      // Count the number of additions (by uniq identifiers) of onStartFns entries
+      expect(asyncProcess.fns.onStartFns.size).toEqual(4)
 
       expect(data).toEqual({
         id: 1,
         name: 'Bob'
       })
 
-      expect(asyncProcessBaseIdentifiers).toEqual(['loadFoo', 'dep1/dep2'])
+      expect(asyncProcessBaseIdentifiers).toEqual(['loadFoo', 'id1/id2'])
     })
   })
 
@@ -370,7 +449,7 @@ describe('AsyncProcess', () => {
       const successSpy = jest.fn()
 
       const foo1 = getAsyncProcessTestInstance('loadFoo')
-      foo1.onSuccess(() => successSpy())
+      foo1.onSuccess(successSpy)
       const foo2 = getAsyncProcessTestInstance('loadFoo')
 
       const bar1 = getAsyncProcessTestInstance('loadBar')
@@ -390,7 +469,7 @@ describe('AsyncProcess', () => {
       const successSpy = jest.fn()
 
       const foo1 = getAsyncProcessTestInstance('loadFoo')
-      foo1.onSuccess(() => successSpy())
+      foo1.onSuccess(successSpy)
 
       const foo1Dep1 = getAsyncProcessTestInstance('loadFoo', ['dep1'])
       const foo2Dep1 = getAsyncProcessTestInstance('loadFoo', ['dep1'])

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -13,7 +13,7 @@ describe('AsyncProcess', () => {
   describe.each<IAsyncProcessOptions>([
     { deleteFunctionsWhenStarted: false },
     { deleteFunctionsWhenStarted: true }
-  ])('According to options: %o', ({ deleteFunctionsWhenStarted }) => {
+  ])('With options: %o', ({ deleteFunctionsWhenStarted }) => {
     let data: Maybe<IData> = null
 
     const setData = (data_: any) => {
@@ -303,7 +303,7 @@ describe('AsyncProcess', () => {
     })
 
     describe('Predicates', () => {
-      it('should execute the async process if the predicate function is true', async () => {
+      it('should execute jobs if the predicate function is true', async () => {
         const fetchData = jest.fn()
         const predicateFn1 = jest.fn().mockImplementation(() => true)
         const predicateFn2 = jest.fn().mockImplementation(() => true)
@@ -329,7 +329,7 @@ describe('AsyncProcess', () => {
         expect(onErrorFn).not.toHaveBeenCalled()
       })
 
-      it('should not execute the async process if the predicate function is false', async () => {
+      it('should not execute jobs if the predicate function is false', async () => {
         const fetchData = jest.fn()
         const predicateFn1 = jest.fn().mockImplementation(() => false)
         const onStartFn = jest.fn()
@@ -352,7 +352,7 @@ describe('AsyncProcess', () => {
         expect(onErrorFn).not.toHaveBeenCalled()
       })
 
-      it('should not execute the async process if one of the predicate functions is false', async () => {
+      it('should not execute jobs if one of the predicate functions is false', async () => {
         const fetchData = jest.fn()
         const predicateFn1 = jest.fn().mockImplementation(() => true)
         const predicateFn2 = jest.fn().mockImplementation(() => true)

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -16,10 +16,10 @@ describe('AsyncProcess', () => {
       }
     }
   ])('With options: %o', options => {
-    function getAsyncProcessTestInstance<R>(
+    function getAsyncProcessTestInstance<R = any, E = any>(
       identifier: AsyncProcessTestIdentifier,
       subIdentifiers?: string[]
-    ): AsyncProcess<AsyncProcessTestIdentifier, R> {
+    ): AsyncProcess<AsyncProcessTestIdentifier, R, E> {
       return AsyncProcess.instance(identifier, subIdentifiers).setOptions(
         options
       )
@@ -192,8 +192,10 @@ describe('AsyncProcess', () => {
           .mockImplementation(() =>
             Promise.reject(new CustomError('Something bad happened'))
           )
-        const asyncProcess =
-          getAsyncProcessTestInstance('loadFoo').do(fetchData)
+
+        const asyncProcess = getAsyncProcessTestInstance<unknown, CustomError>(
+          'loadFoo'
+        ).do(fetchData)
 
         await asyncProcess.start()
 

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -11,9 +11,9 @@ type AsyncProcessTestIdentifier = 'loadFoo' | 'loadBar'
 
 describe('AsyncProcess', () => {
   describe.each<IAsyncProcessOptions>([
-    { deleteFunctionsWhenStarted: false },
-    { deleteFunctionsWhenStarted: true }
-  ])('With options: %o', ({ deleteFunctionsWhenStarted }) => {
+    { deleteFunctionsWhenJobsStarted: false },
+    { deleteFunctionsWhenJobsStarted: true }
+  ])('With options: %o', ({ deleteFunctionsWhenJobsStarted }) => {
     let data: Maybe<IData> = null
 
     const setData = (data_: any) => {
@@ -25,7 +25,7 @@ describe('AsyncProcess', () => {
       subIdentifiers?: string[]
     ): AsyncProcess<AsyncProcessTestIdentifier> {
       return AsyncProcess.instance(identifier, subIdentifiers).setOptions({
-        deleteFunctionsWhenStarted
+        deleteFunctionsWhenJobsStarted
       })
     }
 
@@ -240,6 +240,9 @@ describe('AsyncProcess', () => {
 
           // register only `startSpy2` because added last
           expect(foo1.fns.onStartFns.size).toBe(1)
+          expect(Array.from(foo1.fns.onStartFns.values())).toEqual([
+            new Set([startSpy2])
+          ])
         })
       })
 
@@ -443,7 +446,7 @@ describe('AsyncProcess', () => {
 
         // Count the number of additions (by uniq identifiers) of onStartFns entries
         expect(asyncProcess.fns.onStartFns.size).toEqual(
-          deleteFunctionsWhenStarted ? 0 : 4
+          deleteFunctionsWhenJobsStarted ? 0 : 4
         )
 
         expect(data).toEqual({
@@ -503,7 +506,7 @@ describe('AsyncProcess', () => {
     })
 
     describe('Options', () => {
-      describe('deleteFunctionsWhenStarted', () => {
+      describe('deleteFunctionsWhenJobsStarted', () => {
         it('should reset functions when async process is started', async () => {
           const successSpy1 = jest.fn()
           const successSpy2 = jest.fn()
@@ -521,7 +524,7 @@ describe('AsyncProcess', () => {
           foo1.onSuccess(successSpy3, 'success3')
 
           expect(foo1.fns.onSuccessFns.size).toBe(
-            deleteFunctionsWhenStarted ? 1 : 3
+            deleteFunctionsWhenJobsStarted ? 1 : 3
           )
         })
       })

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -185,11 +185,15 @@ describe('AsyncProcess', () => {
         expect(onErrorFn).toHaveBeenCalledWith(error)
       })
 
-      it('should expose the Error', async () => {
+      it('should expose the Error object as it', async () => {
+        class CustomError {
+          constructor(readonly error: string) {}
+        }
+
         const fetchData = (): Promise<any> => {
           return new Promise((_, reject) => {
             setTimeout(() => {
-              reject(new Error('Something bad happened'))
+              reject(new CustomError('Something bad happened'))
             }, 50)
           })
         }
@@ -200,8 +204,10 @@ describe('AsyncProcess', () => {
         await asyncProcess.start()
 
         expect(data).toEqual(null)
-        expect(asyncProcess.error).toBeInstanceOf(Error)
-        expect(asyncProcess.error?.message).toEqual('Something bad happened')
+        expect(asyncProcess.error).toBeInstanceOf(CustomError)
+        expect(asyncProcess.error).toEqual(
+          new CustomError('Something bad happened')
+        )
       })
 
       it('should return a success promise even if an error occurred', async () => {

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -1,6 +1,6 @@
 import { Maybe } from '@productive-codebases/toolbox'
 import { AsyncProcess } from '../AsyncProcess'
-import { debug, logger } from '../logger'
+import { debug } from '../logger'
 import { IAsyncProcessOptions } from '../types'
 
 interface IData {
@@ -317,14 +317,17 @@ describe('AsyncProcess', () => {
         const fetchData = jest.fn()
         const predicateFn1 = jest.fn().mockImplementation(() => true)
         const predicateFn2 = jest.fn().mockImplementation(() => true)
+        const predicateFn3 = jest.fn().mockImplementation(() => true)
+        const predicateFn4 = jest.fn().mockImplementation(() => true)
         const onStartFn = jest.fn()
         const onSuccessFn = jest.fn()
         const onErrorFn = jest.fn()
 
         const asyncProcess = getAsyncProcessTestInstance('loadFoo')
           .do(fetchData)
-          .if(predicateFn1)
-          .if(predicateFn2)
+          .if(predicateFn1, 'predicate1')
+          .if(predicateFn2, 'predicate2')
+          .if([predicateFn3, predicateFn4], 'predicate3and4')
           .onStart(onStartFn)
           .onSuccess(onSuccessFn)
           .onError(onErrorFn)
@@ -333,6 +336,8 @@ describe('AsyncProcess', () => {
 
         expect(predicateFn1).toHaveBeenCalled()
         expect(predicateFn2).toHaveBeenCalled()
+        expect(predicateFn3).toHaveBeenCalled()
+        expect(predicateFn4).toHaveBeenCalled()
         expect(fetchData).toHaveBeenCalled()
         expect(onStartFn).toHaveBeenCalled()
         expect(onSuccessFn).toHaveBeenCalled()
@@ -367,15 +372,16 @@ describe('AsyncProcess', () => {
         const predicateFn1 = jest.fn().mockImplementation(() => true)
         const predicateFn2 = jest.fn().mockImplementation(() => true)
         const predicateFn3 = jest.fn().mockImplementation(() => false)
+        const predicateFn4 = jest.fn().mockImplementation(() => true)
         const onStartFn = jest.fn()
         const onSuccessFn = jest.fn()
         const onErrorFn = jest.fn()
 
         const asyncProcess = getAsyncProcessTestInstance('loadFoo')
           .do(fetchData)
-          .if(predicateFn1)
-          .if(predicateFn2)
-          .if(predicateFn3)
+          .if(predicateFn1, 'predicate1')
+          .if(predicateFn2, 'predicate2')
+          .if([predicateFn3, predicateFn4], 'predicate3and4')
           .onStart(onStartFn)
           .onSuccess(onSuccessFn)
           .onError(onErrorFn)
@@ -385,6 +391,8 @@ describe('AsyncProcess', () => {
         expect(predicateFn1).toHaveBeenCalled()
         expect(predicateFn2).toHaveBeenCalled()
         expect(predicateFn3).toHaveBeenCalled()
+        // not called because predicateFn3 is falsy
+        expect(predicateFn4).not.toHaveBeenCalled()
         expect(fetchData).not.toHaveBeenCalled()
         expect(onStartFn).not.toHaveBeenCalled()
         expect(onSuccessFn).toHaveBeenCalled()
@@ -590,7 +598,7 @@ describe('AsyncProcess', () => {
           const onSuccessFn = jest.fn()
           const onErrorFn = jest.fn()
 
-          await getAsyncProcessTestInstance('loadFoo')
+          const asyncProcess = getAsyncProcessTestInstance('loadFoo')
             .setOptions({
               debug: {
                 logFunctionRegistrations: true,
@@ -602,7 +610,8 @@ describe('AsyncProcess', () => {
             .onStart(onStartFn)
             .onSuccess(onSuccessFn)
             .onError(onErrorFn)
-            .start()
+
+          await asyncProcess.start()
 
           expect(logs).toMatchSnapshot()
         })

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -3,11 +3,6 @@ import { AsyncProcess } from '../AsyncProcess'
 import { debug } from '../logger'
 import { IAsyncProcessOptions } from '../types'
 
-interface IData {
-  id: number
-  name: string
-}
-
 type AsyncProcessTestIdentifier = 'loadFoo' | 'loadBar'
 
 describe('AsyncProcess', () => {
@@ -21,10 +16,10 @@ describe('AsyncProcess', () => {
       }
     }
   ])('With options: %o', options => {
-    function getAsyncProcessTestInstance(
+    function getAsyncProcessTestInstance<R>(
       identifier: AsyncProcessTestIdentifier,
       subIdentifiers?: string[]
-    ): AsyncProcess<AsyncProcessTestIdentifier> {
+    ): AsyncProcess<AsyncProcessTestIdentifier, R> {
       return AsyncProcess.instance(identifier, subIdentifiers).setOptions(
         options
       )
@@ -104,8 +99,10 @@ describe('AsyncProcess', () => {
           .fn()
           .mockImplementation(() => Promise.resolve({ foo: 'bar' }))
 
-        const asyncProcess =
-          getAsyncProcessTestInstance('loadFoo').do(fetchData)
+        // typings are only indicative, no validation is sone by AsyncProcess
+        const asyncProcess = getAsyncProcessTestInstance<{ foo: string }>(
+          'loadFoo'
+        ).do(fetchData)
 
         await asyncProcess.start()
 
@@ -128,7 +125,7 @@ describe('AsyncProcess', () => {
 
         await asyncProcess.start()
 
-        expect(asyncProcess.result).toEqual([{ foo: 'bar' }, { foo2: 'bar2' }])
+        expect(asyncProcess.result).toEqual({ foo: 'bar', foo2: 'bar2' })
       })
     })
 

--- a/src/__tests__/AsyncProcess.test.ts
+++ b/src/__tests__/AsyncProcess.test.ts
@@ -6,11 +6,20 @@ import { IAsyncProcessOptions } from '../types'
 type AsyncProcessTestIdentifier = 'loadFoo' | 'loadBar'
 
 describe('AsyncProcess', () => {
-  describe.each<Partial<IAsyncProcessOptions>>([
+  describe.each<
+    Partial<
+      IAsyncProcessOptions & {
+        _debug: {
+          logFunctionRegistrations: boolean
+          logFunctionExecutions: boolean
+        }
+      }
+    >
+  >([
     { deleteFunctionsWhenJobsStarted: false },
     { deleteFunctionsWhenJobsStarted: true },
     {
-      debug: {
+      _debug: {
         logFunctionRegistrations: true,
         logFunctionExecutions: true
       }
@@ -591,7 +600,7 @@ describe('AsyncProcess', () => {
 
         beforeEach(() => {
           debug.enable(
-            options.debug?.logFunctionExecutions ? 'AsyncProcess:*' : false
+            options._debug?.logFunctionExecutions ? 'AsyncProcess:*' : false
           )
 
           debug.formatters.s = (s: string) => {
@@ -616,12 +625,6 @@ describe('AsyncProcess', () => {
           const onErrorFn = jest.fn()
 
           await getAsyncProcessTestInstance('loadFoo')
-            .setOptions({
-              debug: {
-                logFunctionRegistrations: true,
-                logFunctionExecutions: true
-              }
-            })
             .do(fetchData)
             .if(predicateFn1)
             .onStart(onStartFn)
@@ -640,12 +643,6 @@ describe('AsyncProcess', () => {
           const onErrorFn = jest.fn()
 
           const asyncProcess = getAsyncProcessTestInstance('loadFoo')
-            .setOptions({
-              debug: {
-                logFunctionRegistrations: true,
-                logFunctionExecutions: true
-              }
-            })
             .do(fetchData)
             .if(predicateFn1)
             .onStart(onStartFn)

--- a/src/__tests__/__snapshots__/AsyncProcess.test.ts.snap
+++ b/src/__tests__/__snapshots__/AsyncProcess.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AsyncProcess With options: {
+  debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
+} Options Logging should log different events if error 1`] = `
+[
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register jobs function(s) with the identifier "defaultJobs"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onStart function(s) with the identifier "defaultOnStart"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onSuccess function(s) with the identifier "defaultOnSuccess"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onError function(s) with the identifier "defaultOnError"",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultOnStart"",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultJobs"",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute onError functions with the identifier "defaultOnError"",
+]
+`;
+
+exports[`AsyncProcess With options: {
+  debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
+} Options Logging should log different events if success 1`] = `
+[
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register jobs function(s) with the identifier "defaultJobs"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onStart function(s) with the identifier "defaultOnStart"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onSuccess function(s) with the identifier "defaultOnSuccess"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onError function(s) with the identifier "defaultOnError"",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultOnStart"",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultJobs"",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultOnSuccess"",
+]
+`;
+
+exports[`AsyncProcess With options: { deleteFunctionsWhenJobsStarted: false } Options Logging should log different events if error 1`] = `[]`;
+
+exports[`AsyncProcess With options: { deleteFunctionsWhenJobsStarted: false } Options Logging should log different events if success 1`] = `[]`;
+
+exports[`AsyncProcess With options: { deleteFunctionsWhenJobsStarted: true } Options Logging should log different events if error 1`] = `[]`;
+
+exports[`AsyncProcess With options: { deleteFunctionsWhenJobsStarted: true } Options Logging should log different events if success 1`] = `[]`;

--- a/src/__tests__/__snapshots__/AsyncProcess.test.ts.snap
+++ b/src/__tests__/__snapshots__/AsyncProcess.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AsyncProcess With options: {
-  debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
+  _debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
 } Options Logging should log different events if error 1`] = `
 [
   "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultJobs" jobs function(s)",
@@ -15,7 +15,7 @@ exports[`AsyncProcess With options: {
 `;
 
 exports[`AsyncProcess With options: {
-  debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
+  _debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
 } Options Logging should log different events if success 1`] = `
 [
   "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultJobs" jobs function(s)",

--- a/src/__tests__/__snapshots__/AsyncProcess.test.ts.snap
+++ b/src/__tests__/__snapshots__/AsyncProcess.test.ts.snap
@@ -4,13 +4,13 @@ exports[`AsyncProcess With options: {
   debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
 } Options Logging should log different events if error 1`] = `
 [
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register jobs function(s) with the identifier "defaultJobs"",
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onStart function(s) with the identifier "defaultOnStart"",
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onSuccess function(s) with the identifier "defaultOnSuccess"",
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onError function(s) with the identifier "defaultOnError"",
-  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultOnStart"",
-  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultJobs"",
-  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute onError functions with the identifier "defaultOnError"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultJobs" jobs function(s)",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultOnStart" onStart function(s)",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultOnSuccess" onSuccess function(s)",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultOnError" onError function(s)",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute "defaultOnStart" jobs function(s)",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute "defaultJobs" jobs function(s)",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute "defaultOnError" onError function(s)",
 ]
 `;
 
@@ -18,13 +18,13 @@ exports[`AsyncProcess With options: {
   debug: { logFunctionRegistrations: true, logFunctionExecutions: true }
 } Options Logging should log different events if success 1`] = `
 [
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register jobs function(s) with the identifier "defaultJobs"",
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onStart function(s) with the identifier "defaultOnStart"",
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onSuccess function(s) with the identifier "defaultOnSuccess"",
-  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register onError function(s) with the identifier "defaultOnError"",
-  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultOnStart"",
-  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultJobs"",
-  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute jobs functions with the identifier "defaultOnSuccess"",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultJobs" jobs function(s)",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultOnStart" onStart function(s)",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultOnSuccess" onSuccess function(s)",
+  "AsyncProcess:functionsRegistrations:debug [loadFoo] Register "defaultOnError" onError function(s)",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute "defaultOnStart" jobs function(s)",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute "defaultJobs" jobs function(s)",
+  "AsyncProcess:functionsExecutions:debug [loadFoo] Execute "defaultOnSuccess" jobs function(s)",
 ]
 `;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,14 +1,17 @@
 import { setupLogger } from '@productive-codebases/toolbox'
 
 const loggerMapping = {
-  asyncprocess: {
-    runtime: 'runtime'
+  AsyncProcess: {
+    functionsRegistrations: 'functionsRegistrations',
+    functionsExecutions: 'functionsExecutions'
   }
 }
 
 const { newLogger, debug } = setupLogger(loggerMapping)
 
-export const logger = newLogger('asyncprocess')('runtime')
-export { debug }
+const logger = newLogger('AsyncProcess')
 
+export { logger, debug }
+
+export type LoggerNamespace = Parameters<typeof logger>[0]
 export type Logger = typeof logger

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,8 +35,4 @@ export type AsyncProcessIdentifiers<TIdentifier extends string> = [
 export interface IAsyncProcessOptions {
   // delete registered functions when async process is started
   deleteFunctionsWhenJobsStarted: boolean
-  debug: {
-    logFunctionRegistrations: boolean
-    logFunctionExecutions: boolean
-  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,10 @@
 import { Maybe } from '@productive-codebases/toolbox'
 import { AsyncProcess } from '../AsyncProcess'
 
-export type Fn = () => any
-export type AsyncFn = () => Promise<any>
-export type FnOrAsyncFn = Fn | AsyncFn
-export type Jobs = FnOrAsyncFn | Array<FnOrAsyncFn>
+export type Fn<R> = () => R
+export type AsyncFn<R> = () => Promise<R>
+export type FnOrAsyncFn<R> = Fn<R> | AsyncFn<R>
+export type Jobs<R> = FnOrAsyncFn<R> | Array<FnOrAsyncFn<R>>
 
 export type ErrorFn = (err: unknown) => any
 export type AsyncErrorFn = (err: unknown) => Promise<any>
@@ -19,11 +19,11 @@ export type PredicateFns<TIdentifier extends string> =
   | PredicateFn<TIdentifier>
   | Array<PredicateFn<TIdentifier>>
 
-export interface IAsyncProcessFns {
-  jobs: Map<string, Set<AsyncFn>>
-  onStartFns: Map<string, Set<AsyncFn>>
-  onSuccessFns: Map<string, Set<AsyncFn>>
-  onErrorFns: Map<string, Set<AsyncErrorFn>>
+export interface IAsyncProcessFns<R> {
+  jobs: Map<string, Set<FnOrAsyncFn<R>>>
+  onStartFns: Map<string, Set<FnOrAsyncFn<R>>>
+  onSuccessFns: Map<string, Set<FnOrAsyncFn<R>>>
+  onErrorFns: Map<string, Set<FnOrAsyncErrorFn>>
   predicateFns: Map<string, Set<PredicateFn<any>>>
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ import { AsyncProcess } from '../AsyncProcess'
 export type Fn = () => any
 export type AsyncFn = () => Promise<any>
 export type FnOrAsyncFn = Fn | AsyncFn
-export type AsyncFns = FnOrAsyncFn | Array<FnOrAsyncFn>
+export type Jobs = FnOrAsyncFn | Array<FnOrAsyncFn>
 
 export type ErrorFn = (err: Error) => any
 export type AsyncErrorFn = (err: Error) => Promise<any>
@@ -16,7 +16,7 @@ export type PredicateFn<TIdentifier extends string> = (
 ) => boolean | Promise<boolean>
 
 export interface IAsyncProcessFns {
-  asyncFns: Map<string, Set<AsyncFn>>
+  jobs: Map<string, Set<AsyncFn>>
   onStartFns: Map<string, Set<AsyncFn>>
   onSuccessFns: Map<string, Set<AsyncFn>>
   onErrorFns: Map<string, Set<AsyncErrorFn>>
@@ -28,5 +28,6 @@ export type AsyncProcessIdentifiers<TIdentifier extends string> = [
 ]
 
 export interface IAsyncProcessOptions {
+  // delete registered functions when async process is started
   deleteFunctionsWhenStarted: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,4 +30,8 @@ export type AsyncProcessIdentifiers<TIdentifier extends string> = [
 export interface IAsyncProcessOptions {
   // delete registered functions when async process is started
   deleteFunctionsWhenJobsStarted: boolean
+  debug: {
+    logFunctionRegistrations: boolean
+    logFunctionExecutions: boolean
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,8 +6,8 @@ export type AsyncFn = () => Promise<any>
 export type FnOrAsyncFn = Fn | AsyncFn
 export type Jobs = FnOrAsyncFn | Array<FnOrAsyncFn>
 
-export type ErrorFn = (err: Error) => any
-export type AsyncErrorFn = (err: Error) => Promise<any>
+export type ErrorFn = (err: unknown) => any
+export type AsyncErrorFn = (err: unknown) => Promise<any>
 export type FnOrAsyncErrorFn = ErrorFn | AsyncErrorFn
 export type AsyncErrorFns = FnOrAsyncErrorFn | Array<FnOrAsyncErrorFn>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,3 +26,7 @@ export type AsyncProcessIdentifiers<TIdentifier extends string> = [
   TIdentifier,
   Maybe<string>
 ]
+
+export interface IAsyncProcessOptions {
+  deleteFunctionsWhenStarted: boolean
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,5 +29,5 @@ export type AsyncProcessIdentifiers<TIdentifier extends string> = [
 
 export interface IAsyncProcessOptions {
   // delete registered functions when async process is started
-  deleteFunctionsWhenStarted: boolean
+  deleteFunctionsWhenJobsStarted: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,11 +15,16 @@ export type PredicateFn<TIdentifier extends string> = (
   asyncProcess: AsyncProcess<TIdentifier>
 ) => boolean | Promise<boolean>
 
+export type PredicateFns<TIdentifier extends string> =
+  | PredicateFn<TIdentifier>
+  | Array<PredicateFn<TIdentifier>>
+
 export interface IAsyncProcessFns {
   jobs: Map<string, Set<AsyncFn>>
   onStartFns: Map<string, Set<AsyncFn>>
   onSuccessFns: Map<string, Set<AsyncFn>>
   onErrorFns: Map<string, Set<AsyncErrorFn>>
+  predicateFns: Map<string, Set<PredicateFn<any>>>
 }
 
 export type AsyncProcessIdentifiers<TIdentifier extends string> = [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,10 +6,10 @@ export type AsyncFn<R> = () => Promise<R>
 export type FnOrAsyncFn<R> = Fn<R> | AsyncFn<R>
 export type Jobs<R> = FnOrAsyncFn<R> | Array<FnOrAsyncFn<R>>
 
-export type ErrorFn = (err: unknown) => any
-export type AsyncErrorFn = (err: unknown) => Promise<any>
-export type FnOrAsyncErrorFn = ErrorFn | AsyncErrorFn
-export type AsyncErrorFns = FnOrAsyncErrorFn | Array<FnOrAsyncErrorFn>
+export type ErrorFn<E> = (err: E) => any
+export type AsyncErrorFn<E> = (err: E) => Promise<any>
+export type FnOrAsyncErrorFn<E> = ErrorFn<E> | AsyncErrorFn<E>
+export type AsyncErrorFns<E> = FnOrAsyncErrorFn<E> | Array<FnOrAsyncErrorFn<E>>
 
 export type PredicateFn<TIdentifier extends string> = (
   asyncProcess: AsyncProcess<TIdentifier>
@@ -19,11 +19,11 @@ export type PredicateFns<TIdentifier extends string> =
   | PredicateFn<TIdentifier>
   | Array<PredicateFn<TIdentifier>>
 
-export interface IAsyncProcessFns<R> {
+export interface IAsyncProcessFns<R, E> {
   jobs: Map<string, Set<FnOrAsyncFn<R>>>
   onStartFns: Map<string, Set<FnOrAsyncFn<R>>>
   onSuccessFns: Map<string, Set<FnOrAsyncFn<R>>>
-  onErrorFns: Map<string, Set<FnOrAsyncErrorFn>>
+  onErrorFns: Map<string, Set<FnOrAsyncErrorFn<E>>>
   predicateFns: Map<string, Set<PredicateFn<any>>>
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,10 +16,10 @@ export type PredicateFn<TIdentifier extends string> = (
 ) => boolean | Promise<boolean>
 
 export interface IAsyncProcessFns {
-  asyncFns: Set<AsyncFn>
-  onStartFns: Set<AsyncFn>
-  onSuccessFns: Set<AsyncFn>
-  onErrorFns: Set<AsyncErrorFn>
+  asyncFns: Map<string, Set<AsyncFn>>
+  onStartFns: Map<string, Set<AsyncFn>>
+  onSuccessFns: Map<string, Set<AsyncFn>>
+  onErrorFns: Map<string, Set<AsyncErrorFn>>
 }
 
 export type AsyncProcessIdentifiers<TIdentifier extends string> = [


### PR DESCRIPTION
## Description of the Change

Implements https://github.com/productive-codebases/async-process/issues/5

## v2.0.0

### Added

- :warning: **[breaking-change]** Add an identifier for each function registration. When using the same identifier, **the new registered function(s) replace(s) the previous one(s)**.

- :warning: **[breaking-change]** Add an identifier for predicates functions to mimic to the same behavior as functions registrations. Several predicate functions can now be passed in a single `if()` with a defined identifier. In the same way, if another `if()` predicate is set with the same identifier, **it will override the previous one**.

- Add `deleteFunctionsWhenJobsStarted` option allowing the deletion of registered functions when the jobs are started.

- Add `debug.logFunctionRegistrations` and `debug.logFunctionExecutions` options allowing functions registrations and executions logs. Don't forget to set `DEBUG=AsyncProcess:*` as an environment variable or in your browser's local storage.

- Keep errors thrown by jobs as is.

  Example: If the job is a fetch query and if the response is a 404, the `err` object will be a Response object.

- AsyncProcess instances now accept two more generics, results (`R`) and an error (`E`), allowing to enforce typings of jobs results and jobs exceptions.

## Benefits

<!-- What benefits will be realized by the code change? -->

## Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Testing Instructions

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Checklist

- [x] Tests added
